### PR TITLE
Update datastax to 2.0.1, fixes wrong dependency in maven central.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ repositories {
 }
 
 dependencies {
-    compile "com.datastax.cassandra:cassandra-driver-core:1.0.0",
+    compile "com.datastax.cassandra:cassandra-driver-core:2.0.1",
             "com.typesafe:config:1.0.1",
             "org.clapper:argot_2.10:1.0.1",
             "org.scala-lang:scala-library:2.10.1"

--- a/project/PillarBuild.scala
+++ b/project/PillarBuild.scala
@@ -14,7 +14,7 @@ object PillarBuild extends Build {
   }
 
   val dependencies = Seq(
-    "com.datastax.cassandra" % "cassandra-driver-core" % "2.0.0",
+    "com.datastax.cassandra" % "cassandra-driver-core" % "2.0.1",
     "com.typesafe" % "config" % "1.0.1",
     "org.clapper" %% "argot" % "1.0.1",
     "org.mockito" % "mockito-core" % "1.9.5" % "test",


### PR DESCRIPTION
The build.gradle depended on the cassandra-driver-core 1.0.0 which broke my application with a `ClassNotFoundException: com.datastax.driver.core.Query`

A bit weird is that the pom.xml (at http://repo1.maven.org/maven2/com/streamsend/pillar/1.0.2/pillar-1.0.2.pomhttp://repo1.maven.org/maven2/com/streamsend/pillar/1.0.2/pillar-1.0.2.pom) specifies 1.0.2 - no clue where this is coming from.

Can you push a new release to maven central with the new datastax driver?
