### PR TITLE
Shutdown cluster in migrate & initialize

### DIFF
--- a/src/main/scala/com/streamsend/pillar/CassandraMigrator.scala
+++ b/src/main/scala/com/streamsend/pillar/CassandraMigrator.scala
@@ -13,7 +13,7 @@ class CassandraMigrator(registry: Registry) extends Migrator {
     selectMigrationsToReverse(dateRestriction, appliedMigrations).foreach(_.executeDownStatement(session))
     selectMigrationsToApply(dateRestriction, appliedMigrations).foreach(_.executeUpStatement(session))
 
-    cluster.shutdown
+    cluster.close
   }
 
   def initialize(dataStore: DataStore, replicationOptions: ReplicationOptions = ReplicationOptions.default) {
@@ -30,7 +30,7 @@ class CassandraMigrator(registry: Registry) extends Migrator {
         |  )
       """.stripMargin.format(dataStore.keyspace)
     )
-    cluster.shutdown
+    cluster.close
   }
 
   private def executeIdempotentCommand(session: Session, statement: String) {


### PR DESCRIPTION
This should be done to release resources, which is relevant when used
in a running application (e.g. Play).

Another great thing to accept an existing session in CassandraMigrator,
so that the application using it could just pass the session its
creating anyways. I didn't do this because migrate/initialize right
now accept a DataStore which would then be obsolete, at least it's not
straight forward to allow both - probably there would be 2 constructors:
1 accepting a DataStore and another one accepting a session.
