### PR TITLE
Add migrate/initialize/destroy accepting a Session.

### DIFF
--- a/src/main/scala/com/chrisomeara/pillar/Migrator.scala
+++ b/src/main/scala/com/chrisomeara/pillar/Migrator.scala
@@ -12,10 +12,22 @@ object Migrator {
   }
 }
 
+import com.datastax.driver.core.Session
+
 trait Migrator {
   def migrate(dataStore: DataStore, dateRestriction: Option[Date] = None)
 
+  /**
+   * Run migrations using the provided session. The session must currently be logged in to the keyspace
+   * where migrations shall be run.
+   */
+  def migrate(session: Session, dateRestriction: Option[Date])
+
   def initialize(dataStore: DataStore, replicationOptions: ReplicationOptions = ReplicationOptions.default)
+  // No default replicationOptions again, because this would lead to an error
+  // "multiple overloaded alternatives of method initialize define default arguments"
+  def initialize(session: Session, keyspace: String, replicationOptions: ReplicationOptions)
 
   def destroy(dataStore: DataStore)
+  def destroy(session: Session, keyspace: String)
 }

--- a/src/main/scala/com/chrisomeara/pillar/PrintStreamReporter.scala
+++ b/src/main/scala/com/chrisomeara/pillar/PrintStreamReporter.scala
@@ -2,14 +2,23 @@ package com.chrisomeara.pillar
 
 import java.io.PrintStream
 import java.util.Date
+import com.datastax.driver.core.Session
 
 class PrintStreamReporter(stream: PrintStream) extends com.chrisomeara.pillar.Reporter {
   def initializing(dataStore: DataStore, replicationOptions: ReplicationOptions) {
     stream.println(s"Initializing ${dataStore.name} data store")
   }
 
+  def initializing(session: Session, keyspace: String, replicationOptions: ReplicationOptions) {
+    stream.println(s"Initializing keyspace $keyspace")
+  }
+
   def migrating(dataStore: DataStore, dateRestriction: Option[Date]) {
     stream.println(s"Migrating ${dataStore.name} data store")
+  }
+
+  def migrating(session: Session, dateRestriction: Option[Date]) {
+    stream.println(s"Migrating keyspace ${session.getLoggedKeyspace}")
   }
 
   def applying(migration: Migration) {
@@ -22,5 +31,9 @@ class PrintStreamReporter(stream: PrintStream) extends com.chrisomeara.pillar.Re
 
   def destroying(dataStore: DataStore) {
     stream.println(s"Destroying ${dataStore.name} data store")
+  }
+
+  def destroying(session: Session, keyspace: String) {
+    stream.println(s"Destroying keyspace $keyspace")
   }
 }

--- a/src/main/scala/com/chrisomeara/pillar/Reporter.scala
+++ b/src/main/scala/com/chrisomeara/pillar/Reporter.scala
@@ -1,11 +1,15 @@
 package com.chrisomeara.pillar
 
 import java.util.Date
+import com.datastax.driver.core.Session
 
 trait Reporter {
   def initializing(dataStore: DataStore, replicationOptions: ReplicationOptions)
+  def initializing(session: Session, keyspace: String, replicationOptions: ReplicationOptions)
   def migrating(dataStore: DataStore, dateRestriction: Option[Date])
+  def migrating(session: Session, dateRestriction: Option[Date])
   def applying(migration: Migration)
   def reversing(migration: Migration)
   def destroying(dataStore: DataStore)
+  def destroying(session: Session, keyspace: String)
 }

--- a/src/main/scala/com/chrisomeara/pillar/ReportingMigrator.scala
+++ b/src/main/scala/com/chrisomeara/pillar/ReportingMigrator.scala
@@ -1,6 +1,7 @@
 package com.chrisomeara.pillar
 
 import java.util.Date
+import com.datastax.driver.core.Session
 
 class ReportingMigrator(reporter: Reporter, wrapped: Migrator) extends Migrator {
   def initialize(dataStore: DataStore, replicationOptions: ReplicationOptions) {
@@ -8,13 +9,28 @@ class ReportingMigrator(reporter: Reporter, wrapped: Migrator) extends Migrator 
     wrapped.initialize(dataStore, replicationOptions)
   }
 
+  def initialize(session: Session, keyspace: String, replicationOptions: ReplicationOptions) {
+    reporter.initializing(session, keyspace, replicationOptions)
+    wrapped.initialize(session, keyspace, replicationOptions)
+  }
+
   def migrate(dataStore: DataStore, dateRestriction: Option[Date]) {
     reporter.migrating(dataStore, dateRestriction)
     wrapped.migrate(dataStore, dateRestriction)
   }
 
+  def migrate(session: Session, dateRestriction: Option[Date]) {
+    reporter.migrating(session, dateRestriction)
+    wrapped.migrate(session, dateRestriction)
+  }
+
   def destroy(dataStore: DataStore) {
     reporter.destroying(dataStore)
     wrapped.destroy(dataStore)
+  }
+
+  def destroy(session: Session, keyspace: String) {
+    reporter.destroying(session, keyspace)
+    wrapped.destroy(session, keyspace)
   }
 }


### PR DESCRIPTION
This is useful for apps embedding pillar as a library, so that they can
provide their already existing session.
