### PR TITLE
Update argot to 1.0.3 which is now in maven central

### DIFF
--- a/project/PillarBuild.scala
+++ b/project/PillarBuild.scala
@@ -17,7 +17,7 @@ object PillarBuild extends Build {
   val dependencies = Seq(
     "com.datastax.cassandra" % "cassandra-driver-core" % "2.0.2",
     "com.typesafe" % "config" % "1.0.1",
-    "org.clapper" %% "argot" % "1.0.2-RC1",
+    "org.clapper" %% "argot" % "1.0.3",
     "org.mockito" % "mockito-core" % "1.9.5" % "test",
     "org.scalatest" %% "scalatest" % "2.2.0" % "test"
   )
@@ -62,9 +62,6 @@ object PillarBuild extends Build {
   ).settings(
     assemblyMergeStrategySetting,
     assemblyTestSetting,
-    // magro bintray repo for argot dependency, see also
-    // https://github.com/bmc/argot/pull/11
-    resolvers += "magro bintray repo" at "http://dl.bintray.com/magro/maven",
     libraryDependencies := dependencies,
     name := "pillar",
     organization := "com.chrisomeara",


### PR DESCRIPTION
Also removed the resolver that was added as workaround.

Can you push a new version to maven central with this PR merged?
