### PR TITLE
Introduce execution stages for up and down queries

### DIFF
--- a/src/main/scala/com/chrisomeara/pillar/Migration.scala
+++ b/src/main/scala/com/chrisomeara/pillar/Migration.scala
@@ -5,11 +5,11 @@ import com.datastax.driver.core.Session
 import com.datastax.driver.core.querybuilder.QueryBuilder
 
 object Migration {
-  def apply(description: String, authoredAt: Date, up: String): Migration = {
+  def apply(description: String, authoredAt: Date, up: Seq[String]): Migration = {
     new IrreversibleMigration(description, authoredAt, up)
   }
 
-  def apply(description: String, authoredAt: Date, up: String, down: Option[String]): Migration = {
+  def apply(description: String, authoredAt: Date, up: Seq[String], down: Option[Seq[String]]): Migration = {
     down match {
       case Some(downStatement) =>
         new ReversibleMigration(description, authoredAt, up, downStatement)
@@ -22,7 +22,7 @@ object Migration {
 trait Migration {
   val description: String
   val authoredAt: Date
-  val up: String
+  val up: Seq[String]
 
   def key: MigrationKey = MigrationKey(authoredAt, description)
 
@@ -35,7 +35,8 @@ trait Migration {
   }
 
   def executeUpStatement(session: Session) {
-    session.execute(up)
+
+    up.foreach(session.execute)
     insertIntoAppliedMigrations(session)
   }
 
@@ -60,21 +61,21 @@ trait Migration {
   }
 }
 
-class IrreversibleMigration(val description: String, val authoredAt: Date, val up: String) extends Migration {
+class IrreversibleMigration(val description: String, val authoredAt: Date, val up: Seq[String]) extends Migration {
   def executeDownStatement(session: Session) {
     throw new IrreversibleMigrationException(this)
   }
 }
 
-class ReversibleMigrationWithNoOpDown(val description: String, val authoredAt: Date, val up: String) extends Migration {
+class ReversibleMigrationWithNoOpDown(val description: String, val authoredAt: Date, val up: Seq[String]) extends Migration {
   def executeDownStatement(session: Session) {
     deleteFromAppliedMigrations(session)
   }
 }
 
-class ReversibleMigration(val description: String, val authoredAt: Date, val up: String, val down: String) extends Migration {
+class ReversibleMigration(val description: String, val authoredAt: Date, val up: Seq[String], val down: Seq[String]) extends Migration {
   def executeDownStatement(session: Session) {
-    session.execute(down)
+    down.foreach(session.execute)
     deleteFromAppliedMigrations(session)
   }
 }

--- a/src/main/scala/com/chrisomeara/pillar/Parser.scala
+++ b/src/main/scala/com/chrisomeara/pillar/Parser.scala
@@ -7,22 +7,54 @@ import scala.collection.mutable
 object Parser {
   def apply(): Parser = new Parser
 
-  private val MatchAttribute = """^-- (authoredAt|description|up|down):(.*)$""".r
+  private val MatchAttribute = """^-- (authoredAt|description|up|down|stage):(.*)$""".r
 }
 
 class PartialMigration {
   var description: String = ""
   var authoredAt: String = ""
-  var up = new mutable.MutableList[String]()
-  var down: Option[mutable.MutableList[String]] = None
+
+  var upStages = new mutable.MutableList[String]()
+  var downStages : Option[mutable.MutableList[String]] = None
+
+  var currentUp = new mutable.MutableList[String]()
+  var currentDown: Option[mutable.MutableList[String]] = None
+
+  def rotateUp = {
+    upStages += currentUp.mkString("\n")
+    upStages = upStages.filterNot(line => line.isEmpty)
+    currentUp = new mutable.MutableList[String]()
+  }
+
+  def rotateDown = {
+
+    currentDown match {
+      case Some(currentDownLines) => {
+
+        downStages match {
+          case None => downStages = Some(new mutable.MutableList[String]())
+          case Some(_) => //do nothing
+        }
+
+        downStages = Some(downStages.get += currentDownLines.mkString("\n"))
+      }
+      case None => //do nothing
+    }
+
+    currentDown = None
+  }
 
   def validate: Option[Map[String, String]] = {
+
+    rotateUp
+    rotateDown
+
     val errors = mutable.Map[String, String]()
 
     if (description.isEmpty) errors("description") = "must be present"
     if (authoredAt.isEmpty) errors("authoredAt") = "must be present"
     if (!authoredAt.isEmpty && authoredAtAsLong < 1) errors("authoredAt") = "must be a number greater than zero"
-    if (up.isEmpty) errors("up") = "must be present"
+    if (upStages.isEmpty) errors("up") = "must be present"
 
     if (!errors.isEmpty) Some(errors.toMap) else None
   }
@@ -49,9 +81,14 @@ class Parser {
 
   case object ParsingDown extends ParserState
 
+  case object ParsingUpStage extends ParserState
+
+  case object ParsingDownStage extends ParserState
+
   def parse(resource: InputStream): Migration = {
     val inProgress = new PartialMigration
     var state: ParserState = ParsingAttributes
+
     io.Source.fromInputStream(resource).getLines().foreach {
       line =>
         line match {
@@ -62,13 +99,22 @@ class Parser {
           case MatchAttribute("up", _) =>
             state = ParsingUp
           case MatchAttribute("down", _) =>
-            inProgress.down = Some(new mutable.MutableList[String]())
+            inProgress.rotateUp
+            inProgress.currentDown = Some(new mutable.MutableList[String]())
             state = ParsingDown
+          case MatchAttribute("stage", number) =>
+            state match {
+              case ParsingUp => state = ParsingUpStage
+              case ParsingUpStage => inProgress.rotateUp
+              case ParsingDown => state = ParsingDownStage
+              case ParsingDownStage => inProgress.rotateDown; inProgress.currentDown = Some(new mutable.MutableList[String]())
+            }
           case cql =>
             if (!cql.isEmpty) {
+
               state match {
-                case ParsingUp => inProgress.up += cql
-                case ParsingDown => inProgress.down.get += cql
+                case ParsingUp | ParsingUpStage => inProgress.currentUp += cql
+                case ParsingDown | ParsingDownStage => inProgress.currentDown.get += cql
                 case other => // ignored
               }
             }
@@ -77,14 +123,15 @@ class Parser {
     inProgress.validate match {
       case Some(errors) => throw new InvalidMigrationException(errors)
       case None =>
-        inProgress.down match {
+
+        inProgress.downStages match {
           case Some(downLines) =>
-            if (downLines.isEmpty) {
-              Migration(inProgress.description, new Date(inProgress.authoredAtAsLong), inProgress.up.mkString("\n"), None)
+            if (downLines.filterNot(line => line.isEmpty).isEmpty) {
+              Migration(inProgress.description, new Date(inProgress.authoredAtAsLong), inProgress.upStages, None)
             } else {
-              Migration(inProgress.description, new Date(inProgress.authoredAtAsLong), inProgress.up.mkString("\n"), Some(downLines.mkString("\n")))
+              Migration(inProgress.description, new Date(inProgress.authoredAtAsLong), inProgress.upStages, Some(downLines))
             }
-          case None => Migration(inProgress.description, new Date(inProgress.authoredAtAsLong), inProgress.up.mkString("\n"))
+          case None => Migration(inProgress.description, new Date(inProgress.authoredAtAsLong), inProgress.upStages)
         }
     }
   }

--- a/src/main/scala/com/chrisomeara/pillar/ReportingMigration.scala
+++ b/src/main/scala/com/chrisomeara/pillar/ReportingMigration.scala
@@ -6,7 +6,7 @@ import com.datastax.driver.core.Session
 class ReportingMigration(reporter: Reporter, wrapped: Migration) extends Migration {
   val description: String = wrapped.description
   val authoredAt: Date = wrapped.authoredAt
-  val up: String = wrapped.up
+  val up: Seq[String] = wrapped.up
 
   override def executeUpStatement(session: Session) {
     reporter.applying(wrapped)

--- a/src/test/resources/pillar/migrations/faker/1370028265_creates_events_table_with_stages.cql
+++ b/src/test/resources/pillar/migrations/faker/1370028265_creates_events_table_with_stages.cql
@@ -1,0 +1,29 @@
+-- description: creates events table with stages
+-- authoredAt: 1370023265
+-- up:
+
+-- stage: 1
+CREATE TABLE events (
+  batch_id text,
+  occurred_at uuid,
+  event_type text,
+  payload blob,
+  PRIMARY KEY (batch_id, occurred_at, event_type)
+)
+
+-- stage: 2
+CREATE TABLE events2 (
+  batch_id text,
+  occurred_at uuid,
+  event_type text,
+  payload blob,
+  PRIMARY KEY (batch_id, occurred_at, event_type)
+)
+
+
+-- down:
+-- stage: 1
+DROP TABLE events
+
+-- stage: 2
+DROP TABLE events2

--- a/src/test/scala/com/chrisomeara/pillar/MigrationSpec.scala
+++ b/src/test/scala/com/chrisomeara/pillar/MigrationSpec.scala
@@ -9,20 +9,20 @@ class MigrationSpec extends FunSpec with ShouldMatchers with MockitoSugar {
   describe(".apply") {
     describe("without a down parameter") {
       it("returns an irreversible migration") {
-        Migration.apply("description", new Date(), "up").getClass should be(classOf[IrreversibleMigration])
+        Migration.apply("description", new Date(), Seq("up")).getClass should be(classOf[IrreversibleMigration])
       }
     }
 
     describe("with a down parameter") {
       describe("when the down is None") {
         it("returns a reversible migration with no-op down") {
-          Migration.apply("description", new Date(), "up", None).getClass should be(classOf[ReversibleMigrationWithNoOpDown])
+          Migration.apply("description", new Date(), Seq("up"), None).getClass should be(classOf[ReversibleMigrationWithNoOpDown])
         }
       }
 
       describe("when the down is Some") {
         it("returns a reversible migration with no-op down") {
-          Migration.apply("description", new Date(), "up", Some("down")).getClass should be(classOf[ReversibleMigration])
+          Migration.apply("description", new Date(), Seq("up"), Some(Seq("down"))).getClass should be(classOf[ReversibleMigration])
         }
       }
     }

--- a/src/test/scala/com/chrisomeara/pillar/ParserSpec.scala
+++ b/src/test/scala/com/chrisomeara/pillar/ParserSpec.scala
@@ -27,13 +27,61 @@ class ParserSpec extends FunSpec with BeforeAndAfter with ShouldMatchers {
 
       it("assigns up") {
         val resource = new FileInputStream(migrationPath)
-        Parser().parse(resource).up should equal( """CREATE TABLE events (
+        Parser().parse(resource).up should contain( """CREATE TABLE events (
                                                              |  batch_id text,
                                                              |  occurred_at uuid,
                                                              |  event_type text,
                                                              |  payload blob,
                                                              |  PRIMARY KEY (batch_id, occurred_at, event_type)
                                                              |)""".stripMargin)
+      }
+    }
+
+    describe("1370028265_creates_events_table_with_stages.cql") {
+      val migrationPath = "src/test/resources/pillar/migrations/faker/1370028265_creates_events_table_with_stages.cql"
+
+      it("returns a migration object") {
+        val resource = new FileInputStream(migrationPath)
+        Parser().parse(resource).getClass should be(classOf[ReversibleMigration])
+      }
+
+      it("assigns authoredAt") {
+        val resource = new FileInputStream(migrationPath)
+        Parser().parse(resource).authoredAt should equal(new Date(1370023265))
+      }
+
+      it("assigns description") {
+        val resource = new FileInputStream(migrationPath)
+        Parser().parse(resource).description should equal("creates events table with stages")
+      }
+
+      it("assigns two up stages") {
+        val resource = new FileInputStream(migrationPath)
+        val migration = Parser().parse(resource)
+
+        migration.up should contain( """CREATE TABLE events (
+                                        |  batch_id text,
+                                        |  occurred_at uuid,
+                                        |  event_type text,
+                                        |  payload blob,
+                                        |  PRIMARY KEY (batch_id, occurred_at, event_type)
+                                        |)""".stripMargin)
+
+        migration.up should contain( """CREATE TABLE events (
+                                        |  batch_id text,
+                                        |  occurred_at uuid,
+                                        |  event_type text,
+                                        |  payload blob,
+                                        |  PRIMARY KEY (batch_id, occurred_at, event_type)
+                                        |)""".stripMargin)
+      }
+
+      it("assigns two down stages") {
+        val resource = new FileInputStream(migrationPath)
+        val migration = Parser().parse(resource).asInstanceOf[ReversibleMigration]
+
+        migration.down should contain( """DROP TABLE events""".stripMargin)
+        migration.down should contain( """DROP TABLE events2""".stripMargin)
       }
     }
 
@@ -47,7 +95,7 @@ class ParserSpec extends FunSpec with BeforeAndAfter with ShouldMatchers {
 
       it("assigns down") {
         val resource = new FileInputStream(migrationPath)
-        Parser().parse(resource).asInstanceOf[ReversibleMigration].down should equal("DROP TABLE views")
+        Parser().parse(resource).asInstanceOf[ReversibleMigration].down should contain("DROP TABLE views")
       }
     }
 

--- a/src/test/scala/com/chrisomeara/pillar/PillarLibraryAcceptanceSpec.scala
+++ b/src/test/scala/com/chrisomeara/pillar/PillarLibraryAcceptanceSpec.scala
@@ -13,7 +13,7 @@ class PillarLibraryAcceptanceSpec extends FeatureSpec with GivenWhenThen with Be
   val session = cluster.connect()
   val migrations = Seq(
     Migration("creates events table", new Date(System.currentTimeMillis() - 5000),
-      """
+      Seq("""
         |CREATE TABLE events (
         |  batch_id text,
         |  occurred_at uuid,
@@ -21,31 +21,31 @@ class PillarLibraryAcceptanceSpec extends FeatureSpec with GivenWhenThen with Be
         |  payload blob,
         |  PRIMARY KEY (batch_id, occurred_at, event_type)
         |)
-      """.stripMargin),
+      """.stripMargin)),
     Migration("creates views table", new Date(System.currentTimeMillis() - 3000),
-      """
+      Seq("""
         |CREATE TABLE views (
         |  id uuid PRIMARY KEY,
         |  url text,
         |  person_id int,
         |  viewed_at timestamp
         |)
-      """.stripMargin,
-      Some( """
+      """.stripMargin),
+      Some( Seq("""
               |DROP TABLE views
-            """.stripMargin)),
+            """.stripMargin))),
     Migration("adds user_agent to views table", new Date(System.currentTimeMillis() - 1000),
-      """
+      Seq("""
         |ALTER TABLE views
         |ADD user_agent text
-      """.stripMargin, None), // Dropping a column is coming in Cassandra 2.0
+      """.stripMargin), None), // Dropping a column is coming in Cassandra 2.0
     Migration("adds index on views.user_agent", new Date(),
-      """
+      Seq("""
         |CREATE INDEX views_user_agent ON views(user_agent)
-      """.stripMargin,
-      Some( """
+      """.stripMargin),
+      Some( Seq("""
               |DROP INDEX views_user_agent
-            """.stripMargin))
+            """.stripMargin)))
   )
   val registry = Registry(migrations)
   val migrator = Migrator(registry)

--- a/src/test/scala/com/chrisomeara/pillar/PrintStreamReporterSpec.scala
+++ b/src/test/scala/com/chrisomeara/pillar/PrintStreamReporterSpec.scala
@@ -10,7 +10,7 @@ import org.scalatest.mock.MockitoSugar
 
 class PrintStreamReporterSpec extends FunSpec with MockitoSugar with Matchers with OneInstancePerTest {
   val session = mock[Session]
-  val migration = Migration("creates things table", new Date(1370489972546L), "up", Some("down"))
+  val migration = Migration("creates things table", new Date(1370489972546L), Seq("up"), Some(Seq("down")))
   val output = new ByteArrayOutputStream()
   val stream = new PrintStream(output)
   val reporter = new PrintStreamReporter(stream)

--- a/src/test/scala/com/chrisomeara/pillar/RegistrySpec.scala
+++ b/src/test/scala/com/chrisomeara/pillar/RegistrySpec.scala
@@ -12,7 +12,7 @@ class RegistrySpec extends FunSpec with BeforeAndAfter with ShouldMatchers with 
       describe("with a directory that exists and has migration files") {
         it("returns a registry with migrations") {
           val registry = Registry.fromDirectory(new File("src/test/resources/pillar/migrations/faker/"))
-          registry.all.size should equal(3)
+          registry.all.size should equal(4)
         }
       }
 
@@ -37,8 +37,8 @@ class RegistrySpec extends FunSpec with BeforeAndAfter with ShouldMatchers with 
     val now = new Date()
     val oneSecondAgo = new Date(now.getTime - 1000)
     val migrations = List(
-      Migration("test now", now, "up"),
-      Migration("test just before", oneSecondAgo, "up")
+      Migration("test now", now, Seq("up")),
+      Migration("test just before", oneSecondAgo, Seq("up"))
     )
     val registry = new Registry(migrations)
 


### PR DESCRIPTION
Some of the queries cannot be executed via cassandra driver in a single go. GRANT query is one of the examples. In order to effectively setup some grants the one need to run separate query, for each GRANT:

```java
session.execute("GRANT MODIFY ...");
session.execute("GRANT MODIFY ...");
session.execute("GRANT MODIFY ...");
```
This pull request introduces the notion of stages. Each migration section (up or down) can be segregated with the `--stage` keyword. Queries defined within each stage are executed in a single go (single `session.execute(...)` invocation). Example:

```sql
-- description: created schema
-- authoredAt: 1370023265
-- up:

-- stage: 1
CREATE TABLE events (
  batch_id text,
  occurred_at uuid,
  event_type text,
  payload blob,
  PRIMARY KEY (batch_id, occurred_at, event_type)
)

-- stage: 2
GRANT MODIFY ON events TO test_user 

-- stage: 3
GRANT SELECT ON events TO test_user 
```    

This migration will be applied by running `session.execute()` three times:

1. `session.execute("CREATE TABLE events (...")`
2. `session.execute("GRANT MODIFY ON...")`
3. `session.execute("GRANT SELECT ON...")`

