### PR TITLE
Support Authentication and SSL with Cassandra Migrations

### DIFF
--- a/src/main/scala/com/chrisomeara/pillar/PlainTextAuthProviderFactory.scala
+++ b/src/main/scala/com/chrisomeara/pillar/PlainTextAuthProviderFactory.scala
@@ -1,0 +1,19 @@
+package com.chrisomeara.pillar
+
+import java.io.FileReader
+import java.util.Properties
+
+import com.datastax.driver.core.PlainTextAuthProvider
+import com.google.common.base.Strings
+
+object PlainTextAuthProviderFactory {
+  def fromProperties(properties: Properties): PlainTextAuthProvider = {
+    val username = properties.getProperty("username")
+    val password = properties.getProperty("password")
+    if (Strings.isNullOrEmpty(username) || Strings.isNullOrEmpty(password)) {
+      return null
+    }
+
+    new PlainTextAuthProvider(username, password)
+  }
+}

--- a/src/main/scala/com/chrisomeara/pillar/SslOptionsBuilder.scala
+++ b/src/main/scala/com/chrisomeara/pillar/SslOptionsBuilder.scala
@@ -1,0 +1,33 @@
+package com.chrisomeara.pillar
+
+import java.io.FileInputStream
+import java.security.{SecureRandom, KeyStore}
+import javax.net.ssl.{KeyManager, TrustManagerFactory, SSLContext}
+
+import com.datastax.driver.core.SSLOptions
+
+class SslOptionsBuilder {
+  var keystore: KeyStore = null
+  var trustManagerFactory: TrustManagerFactory = null
+  var sslContext: SSLContext = null
+
+  def withKeyStore(storeFile: String, storePassword: String, storeType: String = "JKS") = {
+    keystore = KeyStore.getInstance(storeType)
+    keystore.load(new FileInputStream(storeFile), storePassword.toCharArray)
+  }
+
+  def withTrustManager(trustManagerAlgorithm: String = TrustManagerFactory.getDefaultAlgorithm) = {
+    trustManagerFactory = TrustManagerFactory.getInstance(trustManagerAlgorithm)
+  }
+
+  def withSslContext(sslContextType: String = "SSL") = {
+    sslContext = SSLContext.getInstance(sslContextType)
+  }
+
+  def build(): SSLOptions = {
+    trustManagerFactory.init(keystore)
+    sslContext.init(new Array[KeyManager](0), trustManagerFactory.getTrustManagers, new SecureRandom())
+
+    new SSLOptions(sslContext, SSLOptions.DEFAULT_SSL_CIPHER_SUITES);
+  }
+}


### PR DESCRIPTION
We wanted to use Pillar for our Cassandra migrations all the way through Production, but we could not see any support for SSL or User Credentials.  These are the changes we made to support both pieces of functionality.

Also included is a separation of the staging of the compiled artifacts and the packaging of those artifacts.  This was needed to introduce a zip package option.

Change Summary:
- Added a new zip-package task to distribute the application as a zip file.
- Added a PlainTextAuthProviderFactory to create a PlainTextAuthProvider instance
   from a properties file containing the credentials for Cassandra.
- Added SslOptionsBuilder for constructing SSL settings to connect to Cassandra.