### PR TITLE
Fix deduplicate error during merge

### DIFF
--- a/project/PillarBuild.scala
+++ b/project/PillarBuild.scala
@@ -10,6 +10,7 @@ object PillarBuild extends Build {
   val assemblyMergeStrategySetting = mergeStrategy in assembly <<= (mergeStrategy in assembly) {
     (old) => {
       case PathList("javax", "servlet", xs@_*) => MergeStrategy.first
+      case "META-INF/io.netty.versions.properties" => MergeStrategy.last
       case x => old(x)
     }
   }


### PR DESCRIPTION
The following files have the same path but slightly different content
(the timestamp at the top and the buildDate):

  netty-buffer-4.0.33.Final.jar:META-INF/io.netty.versions.properties
  netty-codec-4.0.33.Final.jar:META-INF/io.netty.versions.properties
  netty-common-4.0.33.Final.jar:META-INF/io.netty.versions.properties
  netty-handler-4.0.33.Final.jar:META-INF/io.netty.versions.properties
  netty-transport-4.0.33.Final.jar:META-INF/io.netty.versions.properties

Using MergeStrategy.last for the common path prevents a deduplicate
error during sbt assembly.