### PR TITLE
Allow multiple CQL statements under the UP section

### DIFF
--- a/src/test/resources/pillar/migrations/faker/1370028265000_creates_profiles_table.cql
+++ b/src/test/resources/pillar/migrations/faker/1370028265000_creates_profiles_table.cql
@@ -1,0 +1,15 @@
+-- description: creates profiles table and populate
+-- authoredAt: 1370028265000
+-- up:
+
+CREATE TABLE profiles (
+  email text,
+  name text,
+  address text,
+  PRIMARY KEY (email)
+)
+
+INSERT INTO profiles(email, name, address) VALUES(
+  'rich@yopmail.com',
+  'Rich Halle',
+  'Schadowstrasse 124; Dusseldorf')

--- a/src/test/scala/com/chrisomeara/pillar/ParserSpec.scala
+++ b/src/test/scala/com/chrisomeara/pillar/ParserSpec.scala
@@ -86,6 +86,44 @@ class ParserSpec extends FunSpec with BeforeAndAfter with ShouldMatchers {
       }
     }
 
+    describe("1370028265000_creates_profiles_table.cql") {
+      val migrationPath = "src/test/resources/pillar/migrations/faker/1370028265000_creates_profiles_table.cql"
+
+      it("returns a migration object") {
+        val resource = new FileInputStream(migrationPath)
+        Parser().parse(resource).getClass should be(classOf[IrreversibleMigration])
+      }
+
+      it("assigns authoredAt") {
+        val resource = new FileInputStream(migrationPath)
+        Parser().parse(resource).authoredAt should equal(new Date(1370028265000L))
+      }
+
+      it("assigns description") {
+        val resource = new FileInputStream(migrationPath)
+        Parser().parse(resource).description should equal("creates profiles table and populate")
+      }
+
+      it("creates two up statements from the `up` section") {
+        val resource = new FileInputStream(migrationPath)
+        val migration = Parser().parse(resource)
+
+        migration.up should contain(
+          """CREATE TABLE profiles (
+            |  email text,
+            |  name text,
+            |  address text,
+            |  PRIMARY KEY (email)
+            |)""".stripMargin)
+
+        migration.up should contain(
+          """INSERT INTO profiles(email, name, address) VALUES(
+            |  'rich@yopmail.com',
+            |  'Rich Halle',
+            |  'Schadowstrasse 124; Dusseldorf')""".stripMargin)
+      }
+    }
+
     describe("1370028263000_creates_views_table.cql") {
       val migrationPath = "src/test/resources/pillar/migrations/faker/1370028263000_creates_views_table.cql"
 

--- a/src/test/scala/com/chrisomeara/pillar/PillarCommandLineAcceptanceSpec.scala
+++ b/src/test/scala/com/chrisomeara/pillar/PillarCommandLineAcceptanceSpec.scala
@@ -62,7 +62,7 @@ class PillarCommandLineAcceptanceSpec extends FeatureSpec with GivenWhenThen wit
       session.execute(QueryBuilder.select().from(keyspaceName, "views")).all().size() should equal(0)
 
       And("the applied_migrations table records the migrations")
-      session.execute(QueryBuilder.select().from(keyspaceName, "applied_migrations")).all().size() should equal(4)
+      session.execute(QueryBuilder.select().from(keyspaceName, "applied_migrations")).all().size() should equal(5)
 
       And("the first migration was authored at Fri May 31 18:01:02 2013")
       session.execute(QueryBuilder.select().from(keyspaceName, "applied_migrations").where(QueryBuilder.eq("authored_at", 1370023262000L))).all().size() should equal(1)

--- a/src/test/scala/com/chrisomeara/pillar/RegistrySpec.scala
+++ b/src/test/scala/com/chrisomeara/pillar/RegistrySpec.scala
@@ -12,7 +12,7 @@ class RegistrySpec extends FunSpec with BeforeAndAfter with ShouldMatchers with 
       describe("with a directory that exists and has migration files") {
         it("returns a registry with migrations") {
           val registry = Registry.fromDirectory(new File("src/test/resources/pillar/migrations/faker/"))
-          registry.all.size should equal(4)
+          registry.all.size should equal(5)
         }
       }
 


### PR DESCRIPTION
Enhanced the existing implementation by providing the option of having multiple CQL statements under the UP section. Every consecutive statement must be separated by a blank line (Issue #17).